### PR TITLE
Ep 3767

### DIFF
--- a/vue/src/components/EpJulkaisuValidointi/EpJulkaisuValidointi.vue
+++ b/vue/src/components/EpJulkaisuValidointi/EpJulkaisuValidointi.vue
@@ -1,11 +1,6 @@
 <template>
   <div>
-    <IkoniTeksti v-if="!virheita && !huomautuksia" tyyppi="kaikki-kunnossa">
-      {{$t('kaikki-kunnossa')}}
-    </IkoniTeksti>
-
     <template v-if="virheita">
-      <div class="font-weight-bold mt-4 mb-3">{{$t('julkaisun-estavat-virheet')}}</div>
       <VirheHuomautukset :virhehuomautukset="validointi.virheet" tyyppi="virhe"/>
     </template>
 
@@ -24,7 +19,7 @@
 
 <script lang="ts">
 import * as _ from 'lodash';
-import { Prop, Component, Vue, Watch } from 'vue-property-decorator';
+import { Prop, Component, Vue } from 'vue-property-decorator';
 import EpToggle from '@shared/components/forms/EpToggle.vue';
 import VirheHuomautukset from './VirheHuomautukset.vue';
 import IkoniTeksti from './IkoniTeksti.vue';

--- a/vue/src/components/EpValidPopover/EpValidPopover.spec.ts
+++ b/vue/src/components/EpValidPopover/EpValidPopover.spec.ts
@@ -81,12 +81,12 @@ describe('EpValidPopover component', () => {
       },
     });
 
-    expect(wrapper.html()).not.toContain('validointi-ei-virheita');
+    expect(wrapper.html()).not.toContain('ei-julkaisua-estavia-virheita');
     // expect(wrapper.find({ ref: 'ep-progress-popover' }).exists()).toBe(true);
     // (wrapper.vm.$refs['ep-progress-popover'] as any).show();
 
     await localVue.nextTick();
 
-    expect(wrapper.html()).toContain('validointi-ei-virheita');
+    expect(wrapper.html()).toContain('ei-julkaisua-estavia-virheita');
   });
 });

--- a/vue/src/components/EpValidPopover/EpValidPopover.vue
+++ b/vue/src/components/EpValidPopover/EpValidPopover.vue
@@ -44,7 +44,7 @@
               <fas class="text-success" icon="check-circle"/>
             </div>
             <div class="col">
-              {{ $t('validointi-ei-virheita') }}
+              {{ $t('ei-julkaisua-estavia-virheita') }}
             </div>
           </div>
           <div class="ml-3">

--- a/vue/src/translations/locale-fi.json
+++ b/vue/src/translations/locale-fi.json
@@ -287,6 +287,7 @@
     "ei-asetettu": "Ei asetettu",
     "ei-esikatseltavissa": "Ei esikatseltavissa",
     "ei-hakutuloksia": "Ei hakutuloksia",
+    "ei-julkaisua-estavia-virheita": "Ei julkaisua estäviä virheitä",
     "ei-julkaistuja-opetussuunnitelmia": "Ei julkaistuja opetussuunnitelmia",
     "ei-julkaistuja-toteutussuunnitelmia": "Ei julkaistuja toteutussuunnitelmia",
     "ei-julkaisuja": "Ei julkaisuja",
@@ -3984,5 +3985,13 @@
     "ystavien-opetussuunnitelmat-keskeneraiset": "Ystävien keskeneraiset opetussuunnitelmat",
     "osaamiskokonaisuuden-sijainti": "Osaamiskokonaisuuden sijainti",
     "arviointitaulukko-arvosana-otsikko": "Arvosana",
-    "arviointitaulukko-osaaminen-otsikko": "Osaamisen kuvaus"
+    "arviointitaulukko-osaaminen-otsikko": "Osaamisen kuvaus",
+    "validointi-kategoria-KIELISISALTO": "Kielisisältö",
+    "validointi-kategoria-MAARITTELEMATON": "Muut virheet ja huomautukset",
+    "validointi-kategoria-PERUSTE": "Perusteen tiedot",
+    "validointi-kategoria-RAKENNE": "Perusteen rakenne",
+    "validointi-kategoria-TEKSTI": "Tekstikappaleet",
+    "validointi-kategoria-KOODISTO": "Koodisto",
+    "loytyi-julkaisun-estavia-virheita": "Löytyi julkaisun estäviä virheitä",
+    "tutkintonimikkeelta-tai-osaamisalalta-puuttuu-sisalto": "Tutkintonimikkeeltä tai osaamisalalta puuttuu sisältö"
 }


### PR DESCRIPTION
validointi-kategoria -alkuiset käännökset olleet tähän asti eri translate-hakemistossa, joten siirto fronttiin samalla.